### PR TITLE
Fixed bug in HttpClient that prevented array overwrites

### DIFF
--- a/src/Drivers/HttpClient.php
+++ b/src/Drivers/HttpClient.php
@@ -26,7 +26,7 @@ class HttpClient implements IpfsClient
     {
         $this->host = $host;
         $this->port = $port;
-        $this->http = new Client(array_merge_recursive([
+        $this->http = new Client(array_merge([
             RequestOptions::HTTP_ERRORS => false,
             RequestOptions::TIMEOUT => 10.0,
             RequestOptions::HEADERS => [


### PR DESCRIPTION
Thanks for creating this!

I noticed when testing, when I changed the timeout of the HttpClient it wasn't being set correctly. This is due to the nature of recursive array merges, see: https://stitcher.io/blog/merging-multidimensional-arrays-in-php